### PR TITLE
Update OIDC URIs to new endpoints per well-known config

### DIFF
--- a/src/main/resources/openid-provider-sample-AAF.properties
+++ b/src/main/resources/openid-provider-sample-AAF.properties
@@ -23,8 +23,8 @@ preEstablishedRedirUri=/openid-login
 # AAF OpenID
 openid.aaf.clientId=
 openid.aaf.clientSecret=
-openid.aaf.accessTokenUri=https://central.test.aaf.edu.au/providers/op/token
-openid.aaf.userAuthUri=https://central.test.aaf.edu.au/providers/op/authorize
+openid.aaf.accessTokenUri=https://central.test.aaf.edu.au/oidc/token
+openid.aaf.userAuthUri=https://central.test.aaf.edu.au/oidc/authorize
 openid.aaf.scopes=openid,profile,email
 openid.aaf.link=<p>To sign-in using your AAF credentials, please click on the button below.</p><p><a href="/openid-login?providerId=aaf"><img src="/images/aaf_service_223x54.png" /></a></p>
 # Flag that sets if we should be checking email domains 


### PR DESCRIPTION
Update the sample AAF configuration to use the latest endpoints per https://central.test.aaf.edu.au/.well-known/openid-configuration