### PR TITLE
Allow more filtering of openid claims and user properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id "maven-publish"
     id "com.dorongold.task-tree" version "1.5"
     id "com.palantir.git-version" version "0.12.1"
-    id "io.franzbecker.gradle-lombok" version "5.0.0"
+    id "io.freefair.lombok" version "8.14"
     id "io.spring.dependency-management" version "1.0.14.RELEASE"
     id "net.linguica.maven-settings" version "0.5"
     id "org.nrg.xnat.build.xnat-data-builder" version "1.8.7"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/au/edu/qcif/xnat/auth/openid/OpenIdConnectFilter.java
+++ b/src/main/java/au/edu/qcif/xnat/auth/openid/OpenIdConnectFilter.java
@@ -273,10 +273,11 @@ public class OpenIdConnectFilter extends AbstractAuthenticationProcessingFilter 
                     Object objValue = entry.getValue();
                     if (objValue instanceof String) {
                         String value = (String) objValue;
+                        log.info("Applying regex filter {} = {} for provider {}", key, value, providerId);
                         String fieldName = key.substring(prefix.length());
                         String fieldValue = userInfo.get(fieldName);
                         if (fieldValue == null || !fieldValue.matches(value)) {
-                            log.debug("User info field {} with value {} did not pass regex filter {} for provider {}", fieldName, fieldValue, value, providerId);
+                            log.error("User info field {} with value {} did not pass regex filter {} for provider {}", fieldName, fieldValue, value, providerId);
                             return false;
                         }
                     }

--- a/src/main/java/au/edu/qcif/xnat/auth/openid/OpenIdConnectFilter.java
+++ b/src/main/java/au/edu/qcif/xnat/auth/openid/OpenIdConnectFilter.java
@@ -166,19 +166,19 @@ public class OpenIdConnectFilter extends AbstractAuthenticationProcessingFilter 
 
         String providerId = (String) request.getSession().getAttribute("providerId");
 
-        log.info("Getting idToken...");
+        log.debug("Getting idToken...");
         final String idToken      = accessToken.getAdditionalInformation().get("id_token").toString();
         final Jwt    tokenDecoded = JwtHelper.decode(idToken);
 
-        log.info("===== : {}", tokenDecoded.getClaims());
+        log.debug("===== : {}", tokenDecoded.getClaims());
         final Map<String, String> authInfo = GenericUtils.convertToTypedMap(_objectMapper.readValue(tokenDecoded.getClaims(), Map.class), String.class, String.class);
 
         final String userInfoUri = _plugin.getProperty(providerId, "userInfoUri");
         if (!StringUtils.isEmpty(userInfoUri)) {
-            log.info("Getting User Info from {} using token {}", userInfoUri, accessToken.getValue());
+            log.debug("Getting User Info from {} using token {}", userInfoUri, accessToken.getValue());
             Map<String, String> userInfo = getUserInfo(accessToken.getValue(), userInfoUri);
             for (String key : userInfo.keySet()) {
-                log.info("User Info: {} = {}", key, userInfo.get(key));
+                log.debug("User Info: {} = {}", key, userInfo.get(key));
             }
             authInfo.putAll(userInfo);
         }
@@ -273,7 +273,7 @@ public class OpenIdConnectFilter extends AbstractAuthenticationProcessingFilter 
                     Object objValue = entry.getValue();
                     if (objValue instanceof String) {
                         String value = (String) objValue;
-                        log.info("Applying regex filter {} = {} for provider {}", key, value, providerId);
+                        log.debug("Applying regex filter {} = {} for provider {}", key, value, providerId);
                         String fieldName = key.substring(prefix.length());
                         String fieldValue = userInfo.get(fieldName);
                         if (fieldValue == null || !fieldValue.matches(value)) {

--- a/src/main/java/au/edu/qcif/xnat/auth/openid/OpenIdConnectFilter.java
+++ b/src/main/java/au/edu/qcif/xnat/auth/openid/OpenIdConnectFilter.java
@@ -166,11 +166,11 @@ public class OpenIdConnectFilter extends AbstractAuthenticationProcessingFilter 
 
         String providerId = (String) request.getSession().getAttribute("providerId");
 
-        log.debug("Getting idToken...");
+        log.info("Getting idToken...");
         final String idToken      = accessToken.getAdditionalInformation().get("id_token").toString();
         final Jwt    tokenDecoded = JwtHelper.decode(idToken);
 
-        log.debug("===== : {}", tokenDecoded.getClaims());
+        log.info("===== : {}", tokenDecoded.getClaims());
         final Map<String, String> authInfo = GenericUtils.convertToTypedMap(_objectMapper.readValue(tokenDecoded.getClaims(), Map.class), String.class, String.class);
 
         final String userInfoUri = _plugin.getProperty(providerId, "userInfoUri");

--- a/src/main/java/au/edu/qcif/xnat/auth/openid/OpenIdConnectFilter.java
+++ b/src/main/java/au/edu/qcif/xnat/auth/openid/OpenIdConnectFilter.java
@@ -167,7 +167,11 @@ public class OpenIdConnectFilter extends AbstractAuthenticationProcessingFilter 
 
         final String userInfoUri = _plugin.getProperty(providerId, "userInfoUri");
         if (!StringUtils.isEmpty(userInfoUri)) {
+            log.info("Getting User Info from {} using token {}", userInfoUri, accessToken.getValue());
             Map<String, String> userInfo = getUserInfo(accessToken.getValue(), userInfoUri);
+            for (String key : userInfo.keySet()) {
+                log.info("User Info: {} = {}", key, userInfo.get(key));
+            }
             authInfo.putAll(userInfo);
         }
         final OpenIdConnectUserDetails user = new OpenIdConnectUserDetails(providerId, authInfo, accessToken, _plugin);


### PR DESCRIPTION
The plugin allows filtering by email domain, which is useful, but my OpenID provider (Entra in this case) also provides some other things to filter on, which I think make it more secure (tenant-id in this case).  To avoid this plugin being specific to a use case, I thought it was more useful to simply enable a regular expression on any token.  This works in my testing for my case.  The plugin config is simply updated with extra properties that start with `regexFilter.` e.g. for tenant-id in Entra, which is `tid` if I want to add this to filter to the manchester.ac.uk, nhs.net and icr.ac.uk tenants on the `auth0` client, I can add:
`openid.auth0.regexFilter.tid=37c354b2-85b0-47f5-b222-07b48d774ee3|c152cb07-614e-4abb-818a-f035cfa91a77|6138f7b9-eeea-47f7-a06b-b90a692f238e`

This could also potentially remove the need for email domain filtering, since that could be simply done with:
`openid.auth0.regexFilter.email=*\.manchester.ac.uk|*\.nhs.net|*\.icr.ac.uk`

However as I suspect that use case is more common, it may be worth keeping that option too.