### PR TITLE
Updates to allow the plugin to work with Bearer tokens

### DIFF
--- a/src/main/java/au/edu/qcif/xnat/auth/openid/OpenIdAuthPlugin.java
+++ b/src/main/java/au/edu/qcif/xnat/auth/openid/OpenIdAuthPlugin.java
@@ -139,9 +139,8 @@ public class OpenIdAuthPlugin extends BaseXnatSecurityExtension {
         final HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
         // Interrogate request to get providerId (e.g. look at url if nothing
         // else)
-        String providerId = request.getParameter("providerId");
+        String providerId = (String) request.getSession().getAttribute("providerId");
         log.debug("Provider id is: {}", providerId);
-        request.getSession().setAttribute("providerId", providerId);
         final OAuth2RestTemplate template = new OAuth2RestTemplate(getProtectedResourceDetails(providerId), clientContext);
         template.setAccessTokenProvider(ACCESS_TOKEN_PROVIDER_CHAIN);
         return template;


### PR DESCRIPTION
This allows the code to work with Bearer Tokens, which can then let people that have logged in elsewhere with OpenID use a Bearer token to access the server without having to log in again.  This is useful for API use from outside of XNAT.